### PR TITLE
Removed JSCRuntime::internalContext()

### DIFF
--- a/ReactCommon/jsi/JSCRuntime.cpp
+++ b/ReactCommon/jsi/JSCRuntime.cpp
@@ -49,8 +49,6 @@ class JSCRuntime : public jsi::Runtime {
       const std::string& sourceURL) override;
   jsi::Object global() override;
 
-  void *internalContext() override;
-  
   std::string description() override;
 
   bool isInspectable() override;
@@ -401,10 +399,6 @@ jsi::Value JSCRuntime::evaluateJavaScript(
 
 jsi::Object JSCRuntime::global() {
   return createObject(JSContextGetGlobalObject(ctx_));
-}
-
-void *JSCRuntime::internalContext() {
-  return ctx_;
 }
 
 std::string JSCRuntime::description() {

--- a/ReactCommon/jsi/jsi/jsi.h
+++ b/ReactCommon/jsi/jsi/jsi.h
@@ -148,10 +148,6 @@ class Runtime {
  public:
   virtual ~Runtime();
 
-  /// Returns the context. Only use if you know what you are doing.
-  /// For JSCRuntime returns a JSGlobalContextRef
-  virtual void *internalContext() = 0;
-
   /// Evaluates the given JavaScript \c buffer.  \c sourceURL is used
   /// to annotate the stack trace if there is an exception.  The
   /// contents may be utf8-encoded JS source code, or binary bytcode


### PR DESCRIPTION
internalContext() is not needed anymore (the jsi interface is used instead).