### PR TITLE
RN-2841 Memory leak with fetch function

### DIFF
--- a/ReactCommon/jsi/JSCRuntime.cpp
+++ b/ReactCommon/jsi/JSCRuntime.cpp
@@ -630,7 +630,9 @@ jsi::String JSCRuntime::createStringFromUtf8(
     size_t length) {
   std::string tmp(reinterpret_cast<const char*>(str), length);
   JSStringRef stringRef = JSStringCreateWithUTF8CString(tmp.c_str());
-  return createString(stringRef);
+  auto result = createString(stringRef);
+  JSStringRelease(stringRef);
+  return result;
 }
 
 std::string JSCRuntime::utf8(const jsi::String& str) {


### PR DESCRIPTION
From:
https://github.com/facebook/react-native/pull/25884

String data passed from native to js would leak a JSStringRef.