### PR TITLE
Restored internalContext getter

### DIFF
--- a/ReactCommon/jsi/JSCRuntime.cpp
+++ b/ReactCommon/jsi/JSCRuntime.cpp
@@ -49,6 +49,8 @@ class JSCRuntime : public jsi::Runtime {
       const std::string& sourceURL) override;
   jsi::Object global() override;
 
+  void * internalContext() override;
+
   std::string description() override;
 
   bool isInspectable() override;
@@ -399,6 +401,10 @@ jsi::Value JSCRuntime::evaluateJavaScript(
 
 jsi::Object JSCRuntime::global() {
   return createObject(JSContextGetGlobalObject(ctx_));
+}
+
+void * JSCRuntime::internalContext() {
+  return ctx_;
 }
 
 std::string JSCRuntime::description() {

--- a/ReactCommon/jsi/jsi/jsi.h
+++ b/ReactCommon/jsi/jsi/jsi.h
@@ -187,6 +187,10 @@ class Runtime {
   /// \return the global object
   virtual Object global() = 0;
 
+  /// Returns the context. Only use if you know what you are doing.
+  /// For JSCRuntime returns a JSGlobalContextRef
+  virtual void * internalContext() = 0;
+
   /// \return a short printable description of the instance.  This
   /// should only be used by logging, debugging, and other
   /// developer-facing callers.


### PR DESCRIPTION
The `facebook::jsi::Runtime::internalContext` getter was lost during the recent upgrade to 0.60.6. This patch restores it. It is used by the MSEPlayer.